### PR TITLE
Issue #6 bug fix for empty extension list

### DIFF
--- a/src/main/java/ca/corbett/crypttext/extensions/batch/BatchThread.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/batch/BatchThread.java
@@ -183,9 +183,14 @@ public class BatchThread extends SimpleProgressWorker {
             // we'll fire progressBegins with a dummy total of 1, just to get the progress bar up:
             fireProgressBegins(1);
 
-            // Scan our directory:
-            List<File> files = FileSystemUtil.findFiles(directory, recursive, extensions);
-
+            // Scan our directory. There's a goofy bug in FileSystemUtil where passing an empty list
+            // of extensions to findFiles() will always return an empty list, which is not what we need here.
+            // So, if our extension list is empty, we'll call findFilesExcluding() instead, which has
+            // the expected behavior of returning all files when given an empty list.
+            List<File> files = extensions.isEmpty()
+                    ? FileSystemUtil.findFilesExcluding(directory, recursive, extensions)
+                    : FileSystemUtil.findFiles(directory, recursive, extensions);
+                    
             // Now we can properly set the bounds of our progress bar:
             fireProgressBegins(files.size()); // A bit wonky to fire "begins" twice, but it is what it is.
 

--- a/src/main/java/ca/corbett/crypttext/extensions/batch/BatchThread.java
+++ b/src/main/java/ca/corbett/crypttext/extensions/batch/BatchThread.java
@@ -190,7 +190,6 @@ public class BatchThread extends SimpleProgressWorker {
             List<File> files = extensions.isEmpty()
                     ? FileSystemUtil.findFilesExcluding(directory, recursive, extensions)
                     : FileSystemUtil.findFiles(directory, recursive, extensions);
-                    
             // Now we can properly set the bounds of our progress bar:
             fireProgressBegins(files.size()); // A bit wonky to fire "begins" twice, but it is what it is.
 


### PR DESCRIPTION
This PR addresses issue #6 by fixing a bug where an empty file extension list would incorrectly return NO results, instead of the expected ALL results. This turned out to be a bug in the upstream `FileSystemUtil` class in the `swing-extras` library. Fortunately, there is a fairly easy workaround available in `swing-extras` - we just need to invoke `findFilesExcluding()` instead of `findFiles()` if our extension list is empty. 

Closes #6 